### PR TITLE
Fix `Wrapper.js` import filename in `index.js`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { render as svgRender } from "./logoSvg";
 import { defaultSettings } from "./defaultSettings";
 import "./style.css";
 import favicon from "./favicon.png";
-import { Wrapper } from "./wrapper";
+import { Wrapper } from "./Wrapper";
 import { type RenderSettings } from "./logo";
 import { spiral, cos, sin } from "./rays";
 


### PR DESCRIPTION
Summary:
This repo didn’t build on POSIX-compliant filesystems, because a source
flie imported `wrapper.js`, which does not exist: only `Wrapper.js`
exists.

Test Plan:
On a POSIX-compliant filesystem, run

```shell
git ls-files -z '*.js' ':!docs' |
xargs -0 -n 1 -- sh -c '
    grep -Po '\''(?<=from ")\.[^"]*'\'' "$1" |
    awk -v d="$(dirname "$1")" '\''{ print d "/" $0 }'\'' |
    sed -e "s#/\./#/#g" -e '\''/\.[a-z]*$/!s/$/.js/'\''
' unused |
sort -u |
while read f; do
    if ! [ -f "$f" ]; then
        printf >&2 '%s\n' "$f"
    fi
done
```

and verify that before this change it prints `src/wrapper.js` but after
this change it prints nothing.

Also, check that `yarn start` fails before this change but passes after.

wchargin-branch: fix-wrapper-import