### PR TITLE
Fix `className` error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,7 @@ export class Landing extends React.Component<{}> {
         </div>
 
         <div id="how-sourcecred-works">
-          <h2 class="section-header">how SourceCred works</h2>
+          <h2 className="section-header">how SourceCred works</h2>
 
           <p>
             Everything people do to support a project—like writing code, filing
@@ -235,7 +235,7 @@ export class Landing extends React.Component<{}> {
           </p>
         </div>
 
-        <h2 class="section-header">properties</h2>
+        <h2 className="section-header">properties</h2>
         <div className="card-container">
           <Card settings={settings.sectionDataDriven} title={"Data Driven"}>
             <p>


### PR DESCRIPTION
Summary:
JavaScript and JSX use `className` to avoid conflicts with the `class`
keyword. This commit fixes an erroneous usage of `class`, which was
causing a React error.

Test Plan:
Patch in #1, then run `yarn start` and open the site in a browser. Note
an error “Invalid DOM property `class`. Did you mean `className`?”
before this commit, and the absence of such an error after it.

Also, run `git grep -F 'class='` and note that there are now no results.

wchargin-branch: fix-classname