### PR TITLE
Fix haloing in SVG rendering

### DIFF
--- a/src/logoSvg.js
+++ b/src/logoSvg.js
@@ -38,12 +38,6 @@ export function render(g: any, size: number, settings: RenderSettings) {
     .attr("fill", backgroundColor)
     .attr("r", backgroundRadius);
 
-  // Add the pupil
-  internal
-    .append("circle")
-    .attr("fill", pupilColor)
-    .attr("r", backgroundRadius * pupil);
-
   const layers = ["base", "mid", "edge"];
   const color = scaleOrdinal()
     .domain(layers)
@@ -55,18 +49,24 @@ export function render(g: any, size: number, settings: RenderSettings) {
   const arc = d3Arc()
     .startAngle((d) => ((reverseMult * d.i) / nRays) * TAU)
     .endAngle((d) => ((reverseMult * d.i) / nRays) * TAU - width)
-    .innerRadius((d) => toPix(d.y0))
+    .innerRadius((d) => 0)
     .outerRadius((d) => toPix(d.y1));
 
-  layers.forEach((layer, layer_index) => {
+  for (let i = layers.length - 1; i >= 0; i--) {
+    const layer = layers[i];
     const rays = internal
       .selectAll(`.ray-${layer}`)
-      .data(data[layer_index], (d) => d.i + "-" + layer);
-
+      .data(data[i], (d) => d.i + "-" + layer);
     rays
       .enter()
       .append("path")
       .attr("d", arc)
       .attr("fill", (d) => color(layer));
-  });
+  }
+
+  // Add the pupil
+  internal
+    .append("circle")
+    .attr("fill", pupilColor)
+    .attr("r", backgroundRadius * pupil);
 }


### PR DESCRIPTION
Summary:
Rendering disjoint antialiased shapes with shared boundary causes
haloing effects: each shape’s boundary, when rasterized, is partially
transparent, but these don’t compose back together to form the desired
fully opaque result, which looks awful. For more words and pictures:
<https://ciechanow.ski/alpha-compositing/#compositing-coverage>

An easy fix is to let each shape be a superset of the last, rather than
letting the pieces “lock together” perfectly, and render everything from
back to front. This may still have artifacts along the radial spokes,
but those should be much harder to see.

Before-and-after screenshot:

![Screenshot with old and new versions plus a blow-up of each][ss]

[ss]: https://user-images.githubusercontent.com/4317806/63207669-f926e980-c07e-11e9-8fd8-e058e6de8625.png

Test Plan:
Inspect the mini-logos on the home page, and make sure that the colors
didn’t get inverted or anything.

wchargin-branch: fix-haloing