### PR TITLE
Run Prettier with SourceCred configuration

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -7,7 +7,7 @@ import { select } from "d3-selection";
 export type Props = {|
   generator: (g: any) => void,
   x: number,
-  y: number
+  y: number,
 |};
 
 export class Wrapper extends React.Component<Props> {

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -8,7 +8,7 @@ export function defaultSettings(): RenderSettings {
   const weights = [
     { fixed: 2, variable: 1 },
     { fixed: 2, variable: 6 },
-    { fixed: 3, variable: 4 }
+    { fixed: 3, variable: 4 },
   ];
   return {
     pupil: 0.4,
@@ -21,6 +21,6 @@ export function defaultSettings(): RenderSettings {
     pupilColor: "#111c27",
     computes,
     weights,
-    reverse: false
+    reverse: false,
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import { spiral, cos, sin } from "./rays";
 const TAU = Math.PI * 2;
 class MiniLogo extends React.Component<{|
   size: number,
-  settings?: RenderSettings
+  settings?: RenderSettings,
 |}> {
   render() {
     const size = this.props.size;
@@ -56,9 +56,9 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 0, variable: 1 },
       { fixed: 0, variable: 1 },
-      { fixed: 0, variable: 1 }
+      { fixed: 0, variable: 1 },
     ],
-    reverse: false
+    reverse: false,
   },
   sectionTransparent: {
     pupil: 0.35,
@@ -73,9 +73,9 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 1, variable: 1 },
       { fixed: 1, variable: 1 },
-      { fixed: 1, variable: 1 }
+      { fixed: 1, variable: 1 },
     ],
-    reverse: false
+    reverse: false,
   },
   sectionExtensible: {
     pupil: 0.35,
@@ -90,9 +90,9 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 0, variable: 1 },
       { fixed: 0, variable: 1 },
-      { fixed: 0, variable: 2 }
+      { fixed: 0, variable: 2 },
     ],
-    reverse: false
+    reverse: false,
   },
   sectionCommunity: {
     pupil: 0.35,
@@ -107,9 +107,9 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 1, variable: 0 },
       { fixed: 0, variable: 2 },
-      { fixed: 0, variable: 1 }
+      { fixed: 0, variable: 1 },
     ],
-    reverse: false
+    reverse: false,
   },
   sectionDecentralized: {
     pupil: 0.35,
@@ -124,9 +124,9 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 0.5, variable: 1 },
       { fixed: 0, variable: 1 },
-      { fixed: 0, variable: 4 }
+      { fixed: 0, variable: 4 },
     ],
-    reverse: false
+    reverse: false,
   },
   sectionIntersubjective: {
     pupil: 0.35,
@@ -141,16 +141,16 @@ const settings: { [string]: RenderSettings } = deepFreeze({
     weights: [
       { fixed: 1, variable: 0 },
       { fixed: 0, variable: 2 },
-      { fixed: 0, variable: 3 }
+      { fixed: 0, variable: 3 },
     ],
-    reverse: false
-  }
+    reverse: false,
+  },
 });
 
 function Card(props: {|
   +settings: RenderSettings,
   title: string,
-  children: any
+  children: any,
 |}) {
   return (
     <div className="card">

--- a/src/logo.js
+++ b/src/logo.js
@@ -25,13 +25,13 @@ export type RenderSettings = {|
   edgeColor: string,
   pupilColor: string,
 
-  reverse: boolean
+  reverse: boolean,
 |};
 
 export type Datum = {|
   +i: number,
   +y0: number,
-  +y1: number
+  +y1: number,
 |};
 export type LogoData = Datum[][];
 // Compute the height of a ray given the index, and the number of rays
@@ -45,19 +45,19 @@ export type RayWeight = {|
   // How much is given to this raygroup as "fixed" (i.e. present when the computed output is 0)
   +fixed: number,
   // How much is given to this rayGroup as variable
-  +variable: number
+  +variable: number,
 |};
 
 export function dataGen(
   nRays: number,
   computes: RayCompute[],
   weights: RayWeight[]
-): number => LogoData {
+): (number) => LogoData {
   if (computes.length !== 3) {
     throw new Error("wrong number of computes");
   }
-  const fixed = weights.map(x => x.fixed);
-  const variable = weights.map(x => x.variable);
+  const fixed = weights.map((x) => x.fixed);
+  const variable = weights.map((x) => x.variable);
   const totalWeight = sum(fixed) + sum(variable);
   return function(rot: number): LogoData {
     rot = rot % (Math.PI * 2);
@@ -65,7 +65,7 @@ export function dataGen(
     return computes.map((c, cIndex) => {
       const thisFixed = fixed[cIndex];
       const thisVariable = variable[cIndex];
-      return range(nRays).map(i => {
+      return range(nRays).map((i) => {
         const raySize =
           (c(i, rot, nRays) * thisVariable + thisFixed) / totalWeight;
         const y0 = lastHeight[i];

--- a/src/logoCanvas.js
+++ b/src/logoCanvas.js
@@ -16,7 +16,7 @@ import {
   type LogoData,
   dataGen,
   type RayWeight,
-  type RenderSettings
+  type RenderSettings,
 } from "./logo";
 
 export function canvasRender(
@@ -34,7 +34,7 @@ export function canvasRender(
     computes,
     weights,
     reverse,
-    pupilColor
+    pupilColor,
   } = renderSettings;
 
   function setupCanvas(canvas: HTMLCanvasElement) {
@@ -61,16 +61,16 @@ export function canvasRender(
   const colors = [baseColor, midColor, edgeColor];
   const rayWidthRadians = (TAU / nRays) * rayWidth;
 
-  const toPix = x => (x * (1 - pupil) * 0.9 + pupil) * backgroundRadius;
+  const toPix = (x) => (x * (1 - pupil) * 0.9 + pupil) * backgroundRadius;
   const reverseMult = reverse ? 1 : -1;
   const arc = d3Arc()
-    .startAngle(d => ((reverseMult * d.i) / nRays) * TAU)
-    .endAngle(d => ((reverseMult * d.i) / nRays) * TAU - rayWidthRadians)
-    .innerRadius(d => toPix(d.y0))
-    .outerRadius(d => toPix(d.y1) + 1)
+    .startAngle((d) => ((reverseMult * d.i) / nRays) * TAU)
+    .endAngle((d) => ((reverseMult * d.i) / nRays) * TAU - rayWidthRadians)
+    .innerRadius((d) => toPix(d.y0))
+    .outerRadius((d) => toPix(d.y1) + 1)
     .context(ctx);
 
-  const redraw = data => {
+  const redraw = (data) => {
     // Add background circle
     ctx.fillStyle = backgroundColor;
     ctx.strokeStyle = "#3f6385";
@@ -90,7 +90,7 @@ export function canvasRender(
       ctx.strokeStyle = colors[i];
       ctx.fillStyle = colors[i];
 
-      layer.forEach(x => {
+      layer.forEach((x) => {
         ctx.beginPath();
         arc(x);
         ctx.fill();
@@ -100,7 +100,7 @@ export function canvasRender(
   };
 
   const gen = dataGen(nRays, computes, weights);
-  const redrawForOffset = o => redraw(gen(o));
+  const redrawForOffset = (o) => redraw(gen(o));
   let offset = 0;
   redrawForOffset(offset);
   interval(() => redrawForOffset((offset += 0.001)), 16);

--- a/src/logoSvg.js
+++ b/src/logoSvg.js
@@ -24,7 +24,7 @@ export function render(g: any, size: number, settings: RenderSettings) {
     midColor,
     edgeColor,
     pupilColor,
-    reverse
+    reverse,
   } = settings;
 
   const backgroundRadius = (size / Math.sqrt(2)) * 0.7;
@@ -50,23 +50,23 @@ export function render(g: any, size: number, settings: RenderSettings) {
     .range([baseColor, midColor, edgeColor]);
   const width = (TAU / nRays) * rayWidth;
 
-  const toPix = x => (x * (1 - pupil) * 0.9 + pupil) * backgroundRadius;
+  const toPix = (x) => (x * (1 - pupil) * 0.9 + pupil) * backgroundRadius;
   const reverseMult = reverse ? 1 : -1;
   const arc = d3Arc()
-    .startAngle(d => ((reverseMult * d.i) / nRays) * TAU)
-    .endAngle(d => ((reverseMult * d.i) / nRays) * TAU - width)
-    .innerRadius(d => toPix(d.y0))
-    .outerRadius(d => toPix(d.y1));
+    .startAngle((d) => ((reverseMult * d.i) / nRays) * TAU)
+    .endAngle((d) => ((reverseMult * d.i) / nRays) * TAU - width)
+    .innerRadius((d) => toPix(d.y0))
+    .outerRadius((d) => toPix(d.y1));
 
   layers.forEach((layer, layer_index) => {
     const rays = internal
       .selectAll(`.ray-${layer}`)
-      .data(data[layer_index], d => d.i + "-" + layer);
+      .data(data[layer_index], (d) => d.i + "-" + layer);
 
     rays
       .enter()
       .append("path")
       .attr("d", arc)
-      .attr("fill", d => color(layer));
+      .attr("fill", (d) => color(layer));
   });
 }

--- a/src/rays.js
+++ b/src/rays.js
@@ -16,7 +16,7 @@ export function spiral(periods: number, offset: ?Radians): RayCompute {
     const rotIndex = ((offset + rot) / TAU) * nRays;
     const r0 = Math.floor(rotIndex) + i;
     const r1 = Math.ceil(rotIndex) + i;
-    const f = x => (periodLength - (x % periodLength)) / periodLength;
+    const f = (x) => (periodLength - (x % periodLength)) / periodLength;
     const rem = rotIndex - Math.floor(rotIndex);
     return f(r0) * (1 - rem) + f(r1) * rem;
   };

--- a/src/style.css
+++ b/src/style.css
@@ -5,15 +5,16 @@
 a:link {
   color: #e7a59a;
 }
-a:visited{
-  color: #CD828F;
+a:visited {
+  color: #cd828f;
 }
 body {
   background-color: #0b1219;
-  color: #FAD9D4;
+  color: #fad9d4;
   padding: 0px;
   margin: 0px;
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 }
 .button-link {
   min-width: 120px;
@@ -24,10 +25,10 @@ body {
   background-color: #282d48;
   color: #ffbc95;
   border: 2px solid #e7a59a;
-  font-family: 'Anonymous';
+  font-family: "Anonymous";
 }
 #tagline {
-  font-family: 'Anonymous';
+  font-family: "Anonymous";
   line-height: 1;
   margin: 20px auto;
 }
@@ -38,13 +39,13 @@ body {
 }
 
 h1 {
-  font-family: 'Anonymous';
+  font-family: "Anonymous";
 }
 h2 {
-  font-family: 'Anonymous';
+  font-family: "Anonymous";
 }
 h3 {
-  font-family: 'Anonymous';
+  font-family: "Anonymous";
   text-transform: lowercase;
 }
 p {
@@ -83,7 +84,7 @@ p {
 }
 .card {
   border: 1px solid #87738c;
-  border-radius: .25rem;
+  border-radius: 0.25rem;
   padding: 12px;
   background-color: #111c27;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,41 +9,41 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader"
-        }
+          loader: "babel-loader",
+        },
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"]
+        use: ["style-loader", "css-loader"],
       },
       {
         test: /\.html$/,
-        use: { loader: "html-loader" }
+        use: { loader: "html-loader" },
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
         use: {
-          loader: "file-loader"
-        }
+          loader: "file-loader",
+        },
       },
       {
         test: /\.(woff|woff2|eot|ttf|otf)$/,
         use: {
-          loader: "file-loader"
-        }
-      }
-    ]
+          loader: "file-loader",
+        },
+      },
+    ],
   },
   plugins: [
     new HtmlWebPackPlugin({
       template: "./src/index.html",
-      filename: "./index.html"
+      filename: "./index.html",
     }),
     new HtmlWebPackPlugin({
       template: "./src/discord-invite.html",
-      filename: "./discord-invite/index.html"
+      filename: "./discord-invite/index.html",
     }),
     new CopyPlugin([{ from: "./src/favicon.png", to: "favicon.png" }]),
-    new CopyPlugin([{ from: "./src/CNAME", to: "CNAME" }])
-  ]
+    new CopyPlugin([{ from: "./src/CNAME", to: "CNAME" }]),
+  ],
 };


### PR DESCRIPTION
Summary:
Some files were not following Prettier style at all (`src/style.css`);
those that were were using the default Prettier options, which have
trailing commas and arrow parentheses disabled and are thus objectively
inferior to the SourceCred settings.

Test Plan:
Running `yarn prettier --check 'src/**/*.'{js,css} webpack.config.js`
now passes.

wchargin-branch: run-prettier