### PR TITLE
Replace hero image `<canvas>` with CSS animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import deepFreeze from "deep-freeze";
-import { canvasRender } from "./logoCanvas";
 import { render as svgRender } from "./logoSvg";
 import { defaultSettings } from "./defaultSettings";
 import "./style.css";
@@ -16,6 +15,7 @@ const TAU = Math.PI * 2;
 class MiniLogo extends React.Component<{|
   size: number,
   settings?: RenderSettings,
+  className?: string,
 |}> {
   render() {
     const size = this.props.size;
@@ -25,7 +25,7 @@ class MiniLogo extends React.Component<{|
       svgRender(g, size, settings);
     }
     return (
-      <svg width={size} height={size}>
+      <svg width={size} height={size} className={this.props.className}>
         <Wrapper generator={svgGen} x={0} y={0} />
       </svg>
     );
@@ -43,6 +43,24 @@ function ButtonLink(props) {
 }
 
 const settings: { [string]: RenderSettings } = deepFreeze({
+  hero: {
+    pupil: 0.4,
+    rayWidth: 0.75,
+    nRays: 20,
+    backgroundColor: "#282d48",
+    baseColor: "#ffbc95",
+    midColor: "#e7a59a",
+    edgeColor: "#87738c",
+    pupilColor: "#111c27",
+    computes: [() => 0, () => 0, () => 0],
+    weights: [
+      { fixed: 0.375, variable: 0.0 },
+      { fixed: 1.0, variable: 0.0 },
+      { fixed: 1.0, variable: 0.0 },
+    ],
+    reverse: false,
+    animate: true,
+  },
   sectionDataDriven: {
     pupil: 0.35,
     rayWidth: 0.65,
@@ -166,7 +184,7 @@ export class Landing extends React.Component<{}> {
     return (
       <div className="container">
         <div>
-          <canvas id="logo-canvas"></canvas>
+          <MiniLogo size={350} settings={settings.hero} className="hero-logo" />
           <h1 id="topline">SourceCred</h1>
           <div id="tagline">
             <h2 className="tagline" id="tagline-top">
@@ -282,11 +300,6 @@ export class Landing extends React.Component<{}> {
         </div>
       </div>
     );
-  }
-
-  componentDidMount() {
-    const canvas: any = document.getElementById("logo-canvas");
-    canvasRender(canvas, defaultSettings());
   }
 }
 

--- a/src/logoSvg.js
+++ b/src/logoSvg.js
@@ -61,7 +61,9 @@ export function render(g: any, size: number, settings: RenderSettings) {
       .enter()
       .append("path")
       .attr("d", arc)
-      .attr("fill", (d) => color(layer));
+      .attr("fill", (d) => color(layer))
+      .attr("data-layer", layer)
+      .classed("logo-ray", true);
   }
 
   // Add the pupil

--- a/src/style.css
+++ b/src/style.css
@@ -124,6 +124,28 @@ p {
   font-size: 2em;
 }
 
+@keyframes breathe {
+  from {
+    transform: scale(0.9);
+  }
+  50% {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.9);
+  }
+}
+
+.hero-logo .logo-ray:not([data-layer="base"]) {
+  animation: breathe 8s infinite both cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+.hero-logo .logo-ray:nth-of-type(2n) {
+  animation-delay: 0s;
+}
+.hero-logo .logo-ray:nth-of-type(2n + 1) {
+  animation-delay: -4s;
+}
+
 @media (min-width: 750px) {
   canvas {
     height: 350px;


### PR DESCRIPTION
Summary:
Using CSS animations has a number of benefits over a canvas:

  - The foundation is a vector format, not a raster format, so it
    renders correctly on all screen sizes and zoom settings.
  - Painting and interpolation is automatically handled by the browser.
    It’ll try to hit 60fps, but will throttle down correctly if it can’t
    hit that (rather than lagging).
  - CSS animations support easing, so changing from linear interpolation
    to smooth interpolation is a one-line change (and still has a lot of
    flexibility: see <https://easings.net/>).
  - The other logos use SVG, so now they can all share one codepath.
  - The code is significantly shorter, simpler, and more declarative.
    It’s a couple lines of JavaScript and a few dozen lines of CSS.
  - It doesn’t need JavaScript to run. No `componentDidMount`, either.

I’ve tried to emulate the old canvas logo’s structure and animated
qualities in this new version (though I did fix the ugly linear
interpolation). It’s pretty close, though not identical. Tweak to taste.

Test Plan:
A side-by-side screenshot of the canvas (left) and SVG animation (right)
clearly shows the quality difference; note pixelation on the left:

![Side-by-side still screenshot of the old (left) and new (right)][ss]

[ss]: https://user-images.githubusercontent.com/4317806/63208450-0cd74d80-c089-11e9-9701-fa127d7b6ec4.png

This video is of lower image quality, but shows the improved dynamics;
note on the left side a sharp transition when the first derivative of
the radius changes sign, compared to a smooth curve on the right side:
see [gfycat preview][gfy] or [download high-quality `.webm`][webm].

[gfy]: https://gfycat.com/sizzlinghonorablegoat
[webm]: https://github.com/sourcecred/website/files/3511777/logo_comparison.webm.gz

wchargin-branch: logo-css-animation
